### PR TITLE
fix: 🐛 Add ability to recover on Postgres transactions

### DIFF
--- a/src/RetryOnDuplicateKey.php
+++ b/src/RetryOnDuplicateKey.php
@@ -6,6 +6,7 @@ namespace Mpyw\LaravelRetryOnDuplicateKey;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\PostgresConnection;
 use Mpyw\LaravelUniqueViolationDetector\UniqueViolationDetector;
 use PDOException;
 
@@ -27,11 +28,11 @@ class RetryOnDuplicateKey
     public function __invoke(callable $callback, ...$args)
     {
         try {
-            return $callback(...$args);
+            return $this->withSavepoint(fn () => $callback(...$args));
         } catch (PDOException $e) {
             if ((new UniqueViolationDetector($this->connection))->violated($e)) {
                 $this->forceReferringPrimaryConnection();
-                return $callback(...$args);
+                return $this->withSavepoint(fn () => $callback(...$args));
             }
             throw $e;
         }
@@ -47,5 +48,28 @@ class RetryOnDuplicateKey
         if ($connection instanceof Connection) {
             $connection->recordsHaveBeenModified();
         }
+    }
+
+    /**
+     * @phpstan-template T
+     * @phpstan-param callable(): T $callback
+     * @phpstan-return T
+     * @return mixed
+     * @noinspection PhpDocMissingThrowsInspection
+     * @noinspection PhpUnhandledExceptionInspection
+     */
+    protected function withSavepoint(callable $callback)
+    {
+        return $this->needsSavepoint()
+            ? $this->connection->transaction(fn () => $callback())
+            : $callback();
+    }
+
+    protected function needsSavepoint(): bool
+    {
+        // In Postgres, savepoints allow recovery from errors.
+        // This ensures retrying should work also in transactions.
+        return $this->connection instanceof PostgresConnection
+            && $this->connection->transactionLevel() > 0;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelRetryOnDuplicateKey\Tests;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Schema;
+use Mpyw\LaravelRetryOnDuplicateKey\ConnectionServiceProvider;
+use Mpyw\LaravelRetryOnDuplicateKey\Tests\Models\User;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+    /**
+     * @var string[]
+     */
+    protected array $queries = [];
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     * @return string[]
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [ConnectionServiceProvider::class];
+    }
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        config([
+            'database.connections' => require __DIR__ . '/config/database.php',
+            'database.default' => getenv('DB') ?: 'sqlite',
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->db()->getDriverName() === 'sqlite') {
+            $this->db()->statement('PRAGMA foreign_keys=true;');
+        }
+
+        // Workaround for https://github.com/laravel/framework/pull/35988
+        $shouldRestartTransaction = false;
+        if ($this->db()->getPdo()->inTransaction()) {
+            $this->db()->getPdo()->commit();
+            $shouldRestartTransaction = true;
+        }
+
+        Schema::dropIfExists('posts');
+        Schema::dropIfExists('users');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->integer('id')->primary();
+            $table->string('email')->unique();
+            $table->enum('type', ['consumer', 'provider']);
+            $table->timestamps();
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->timestamps();
+        });
+
+        // Workaround for https://github.com/laravel/framework/pull/35988
+        if ($shouldRestartTransaction) {
+            $this->db()->getPdo()->beginTransaction();
+        }
+
+        $user = new User();
+        $user->fill(['id' => 1, 'email' => 'example@example.com', 'type' => 'consumer'])->save();
+
+        $this->db()->forgetRecordModificationState();
+
+        $this->db()->beforeExecuting(function (string $query) {
+            $this->queries[] = $query;
+        });
+
+        $this->queries = [];
+    }
+
+    protected function db(): Connection
+    {
+        $connection = App::make(Connection::class);
+        assert($connection instanceof Connection);
+        return $connection;
+    }
+}

--- a/tests/TransactionErrorRecoveryTest.php
+++ b/tests/TransactionErrorRecoveryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelRetryOnDuplicateKey\Tests;
+
+use Illuminate\Database\QueryException;
+use Mpyw\LaravelRetryOnDuplicateKey\Tests\Models\User;
+use Throwable;
+
+class TransactionErrorRecoveryTest extends TestCase
+{
+    /**
+     * @throws Throwable
+     */
+    public function testRecoveryFromTransactionAbortedError(): void
+    {
+        $this->db()->transaction(function () {
+            try {
+                $this->db()->retryOnDuplicateKey(function () {
+                    static $tries = 0;
+
+                    $this->assertSame((bool)$tries++, $this->db()->hasModifiedRecords());
+
+                    $user = new User();
+                    $user->fill(['id' => 2, 'email' => 'example@example.com', 'type' => 'consumer'])->save();
+                });
+            } catch (QueryException $e) {
+                var_dump($e->errorInfo);
+                $this->assertCount(2, $this->queries);
+            }
+
+            $user = new User();
+            $user->fill(['id' => 2, 'email' => 'example-another@example.com', 'type' => 'consumer'])->save();
+            $this->assertCount(3, $this->queries);
+        });
+    }
+}

--- a/tests/TransactionErrorRefreshDatabaseRecoveryTest.php
+++ b/tests/TransactionErrorRefreshDatabaseRecoveryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelRetryOnDuplicateKey\Tests;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mpyw\LaravelRetryOnDuplicateKey\Tests\Models\User;
+use Throwable;
+
+class TransactionErrorRefreshDatabaseRecoveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @throws Throwable
+     */
+    public function testRecoveryFromTransactionAbortedError(): void
+    {
+        try {
+            $this->db()->retryOnDuplicateKey(function () {
+                static $tries = 0;
+
+                $this->assertSame((bool)$tries++, $this->db()->hasModifiedRecords());
+
+                $user = new User();
+                $user->fill(['id' => 2, 'email' => 'example@example.com', 'type' => 'consumer'])->save();
+            });
+        } catch (QueryException $e) {
+            var_dump($e->errorInfo);
+            $this->assertCount(2, $this->queries);
+        }
+
+        $user = new User();
+        $user->fill(['id' => 2, 'email' => 'example-another@example.com', 'type' => 'consumer'])->save();
+        $this->assertCount(3, $this->queries);
+    }
+}


### PR DESCRIPTION
# Overview

In Postgres, you always get errors from any statements when a transaction is aborted due to a unique key constraint error. To recover from the failure, we must create a savepoint before entering the critical section.

- Related: https://github.com/mpyw/laravel-database-advisory-lock/blob/8dfc80a3a62167ef17a3e8b491eb40001541482f/src/PostgresSessionLocker.php#L75-L80

Also, as of PHP 8, implicit commits on MySQL can cause PDO transaction inconsistency errors. We have also implemented a workaround for this on the tests.

- Related: https://github.com/laravel/framework/pull/35988
